### PR TITLE
Fixing DOM access

### DIFF
--- a/pull-to-action.html
+++ b/pull-to-action.html
@@ -262,9 +262,7 @@
 						/** if you're at the top of the container, start animations **/
 						if (container.scrollTop == 0 && scaleStore == 1) {
 							dragStore = endTouchY - startTouchY;
-							//console.log(dragStore);
 							spinStore = spinStore - (dragStore / distance);
-							console.log(spinStore);
 							desatStore = 100 - ((dragStore / distance) * 100);
 							attribute.drag = dragStore;
 							attribute.spin = spinStore;
@@ -301,12 +299,12 @@
 					container.addEventListener('touchend', touchendHandler, false);
 				},
 				updateStyles: function () {
-					var refreshShadow = document.querySelector('.refreshShadow');
+					var refreshShadow = Polymer.dom(this.root).querySelector('.refreshShadow');
 					refreshShadow.style.top = (this.drag - 50) / 3 + 'px';
 					refreshShadow.style.opacity = this.drag / this.distance;
 					refreshShadow.style.transform = 'scale(' + this.scale + ')';
 
-					var refreshIcon = document.querySelector('.refreshIcon');
+					var refreshIcon = Polymer.dom(this.root).querySelector('.refreshIcon');
 					refreshIcon.style.transform = 'rotateZ(' + this.spin + 'deg)';
 					refreshIcon.style.filter = 'grayscale(' + this.desat + '%)';
 				}


### PR DESCRIPTION
Making sure that querySelector uses only the inner nodes of the element
instead of targeting everything.